### PR TITLE
drone tag generating script, remove auto_tag

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -26,6 +26,13 @@ pipeline:
     when:
       event: [pull_request, push, tag]
 
+  generate-build-tags:
+    image: bash
+    commands:
+      - bash drone-gen-versions.sh
+    when:
+      event: [push, tag]
+
   build-docker-image-tag:
     image: plugins/docker
     registry:
@@ -36,7 +43,6 @@ pipeline:
       from_secret: DOCKER_USERNAME
     password:
       from_secret: DOCKER_PASSWORD
-    auto_tag: true
     insecure: true
     file: Dockerfile
     when:

--- a/drone-gen-versions.sh
+++ b/drone-gen-versions.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+echo ${DRONE_COMMIT_REF}
+if [[ "${DRONE_COMMIT_REF}" == "refs/tags/"* ]] ; then
+echo "${DRONE_COMMIT_REF/refs\/tags\//}" > .tags
+fi

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-Django==2.1.5
+Django==2.1.11
 django-filter==2.1.0
 django-health-check==3.8.0
 git+https://github.com/Humanitec/django-oauth-toolkit-jwt@v0.5.3#egg=django-oauth-toolkit-jwt


### PR DESCRIPTION
## Purpose
Drone auto tagging replaces and formats corresponding git tag, e.g. it removes starting 'v'.

## Approach
Switch off auto_tag. Get version from commit_ref and place it in .drone file, so drone could generate the tag without change.
(Also updated Django dependancy due to security alert)